### PR TITLE
Unfinalize `ObjectProxy::__construct()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.4 under development
 
-- no changes in this release.
+- Bug #64: Unfinalize `ObjectProxy::__construct()` (@vjik)
 
 ## 1.0.3 August 15, 2022
 

--- a/src/ObjectProxy.php
+++ b/src/ObjectProxy.php
@@ -89,6 +89,9 @@ class ObjectProxy
      */
     protected function getNewStaticInstance(object $instance): self
     {
+        /**
+         * @psalm-suppress UnsafeInstantiation Constructor should be consistent to `getNewStaticInstance()`.
+         */
         return new static($instance);
     }
 

--- a/src/ObjectProxy.php
+++ b/src/ObjectProxy.php
@@ -13,7 +13,7 @@ class ObjectProxy
 {
     use ProxyTrait;
 
-    final public function __construct(
+    public function __construct(
         /**
          * @var object An instance of the class for proxying method calls.
          */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -